### PR TITLE
updated nginx docs to use 127.0.0.1 instead of YOUR_DOMAIN

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -201,7 +201,7 @@ server {
     }
     
     location /api/ {
-        proxy_pass https://YOUR_DOMAIN:3000/;
+        proxy_pass http://127.0.0.1:3000/;
     }
 }
 ```


### PR DESCRIPTION
I didn't spot this before so setup this PR to fix it now.

in short, the `your_domain` variable is incorrect, at this point in nginx we're already serving your domain - instead we're searching for where to proxy it to.

on that note, using `localhost` is not a good idea because over the past few days I've noticed a bunch of Nginx errors when connecting to localhost (`::1`) over IPv6. Using `127.0.0.1` instead forces IPv4 which is working flawlessly.

Using HTTP instead of HTTPS is better also, as we can terminate SSL at Nginx and there's no real advantages of an SSL connection from Nginx -> Torrust (Unless you're proxying it to another machine/network I guess).